### PR TITLE
Interview API complete

### DIFF
--- a/app/controllers/interviewee/interview.js
+++ b/app/controllers/interviewee/interview.js
@@ -22,5 +22,28 @@ function startTheInterview(req, res, next) {
   });
 }
 
+/**
+ * give the test
+ * @param  {Object}   req  Request Object
+ * @param  {Object}   res  Response Object
+ * @param  {Function} next Function to pass control to the next middleware
+ */
+
+function giveTheInterview(req, res, next) {
+  interviewLib.giveTest(
+    req.user._id,
+    req.body.openingTrackId,
+    req.body.userAns,
+    function(err, fetchedInstance) {
+      if (err) {
+        res.status(500).json(err);
+        return;
+      }
+      res.status(200).json(fetchedInstance);
+    }
+  );
+}
+
 router.get('/start', startTheInterview);
+router.post('/give', giveTheInterview);
 module.exports = router;

--- a/lib/interviewee/interview.js
+++ b/lib/interviewee/interview.js
@@ -3,9 +3,16 @@ const mongoose = require('mongoose');
 const Models = require('../../app/models');
 const openingHelper = require('../../app/helpers/opening_helper');
 const populateHelper = require('../../app/helpers/populate');
+const questionHelper = require('../../app/helpers/question_helper');
 const CONSTANTS = require('../../config/constants');
 const KEYS = require('../../config/keys');
 
+/**
+ * Function to get track details
+ * @param {objectId} userId _id of the user
+ * @param {objectId} trackId _id of the track
+ * @param {Function} callback function with err and track details
+ */
 function getTrackDetails(userId, trackId, callback) {
   Models.InterviewTrack.findOne({
     _id: mongoose.Types.ObjectId(trackId),
@@ -30,6 +37,12 @@ function getTrackDetails(userId, trackId, callback) {
   });
 }
 
+/**
+ * Function to start the test and return question in response
+ * @param {objectId} userId _id of the user
+ * @param {objectId} trackId _id of the track
+ * @param {Function} callback function with err and question
+ */
 function startTest(userId, trackId, callback) {
   async.waterfall(
     [
@@ -63,6 +76,200 @@ function startTest(userId, trackId, callback) {
   );
 }
 
+/**
+ * function to get final score
+ * @param {objectId} questionId _id of the question
+ * @param {object} gotScore object having user text analytics score
+ * @param {Function} callback having err and final score
+ */
+function totalQuestionTags(questionId, gotScore, callback) {
+  Models.Question.findById(questionId, function(err, fetchedQuestion) {
+    if (err) {
+      callback({
+        type: CONSTANTS.ERROR_TYPES.DB_ERROR,
+        msg: 'Unable to update score',
+        errorDetail: String(err),
+      });
+    } else {
+      const score = (
+        gotScore.scored /
+        fetchedQuestion.tags.length *
+        10
+      ).toFixed(2);
+      const finalScore = {
+        textAnalyticsScore: score,
+      };
+      callback(null, finalScore);
+    }
+  });
+}
+
+/**
+ * Function to count matching tags
+ * @param {ObjectId} questionId object id of the question
+ * @param {Array} ansTags array of analysis tags
+ * @param {Function} callback function having err and counted tags
+ */
+function countMatchingTags(questionId, ansTags, callback) {
+  Models.Question.aggregate([
+    {
+      $match: {
+        _id: mongoose.Types.ObjectId(questionId),
+      },
+    },
+    {
+      $unwind: '$tags',
+    },
+    {
+      $match: {
+        tags: {
+          $in: ansTags,
+        },
+      },
+    },
+  ]).exec(function(err, result) {
+    if (err) {
+      callback({
+        type: CONSTANTS.ERROR_TYPES.DB_ERROR,
+        msg: 'Unable to update score',
+        errorDetail: String(err),
+      });
+    } else {
+      const score = {
+        scored: result.length,
+      };
+      callback(null, score);
+    }
+  });
+}
+
+/**
+ * Function to give complete test
+ * @param {objectId} userId _id of the user
+ * @param {ObjectId} trackId _id the interview track
+ * @param {String} userAns user ans for the question
+ * @param {function} callback err and total score with next question
+ */
+function giveTest(userId, trackId, userAns, callback) {
+  if (userAns.length > 1) {
+    async.waterfall(
+      [
+        function(waterfallCallback) {
+          getTrackDetails(userId, trackId, function(err, trackDetails) {
+            waterfallCallback(err, trackDetails);
+          });
+        },
+
+        function(trackDetails, waterfallCallback) {
+          questionHelper.getAzureAnalytics(userAns, function(err, results) {
+            let obj = JSON.parse(results);
+            waterfallCallback(err, trackDetails, obj.documents[0].keyPhrases);
+          });
+        },
+        function(trackDetails, analysisTags, waterfallCallback) {
+          const questionId =
+            trackDetails.questions[trackDetails.count].question_id;
+          countMatchingTags(questionId, analysisTags, function(
+            err,
+            countedTags
+          ) {
+            waterfallCallback(err, countedTags, questionId, trackDetails);
+          });
+        },
+
+        function(gotScore, questionId, trackDetails, waterfallCallback) {
+          totalQuestionTags(questionId, gotScore, function(err, totalScore) {
+            waterfallCallback(err, totalScore, trackDetails);
+          });
+        },
+
+        function(totalScore, trackDetails, waterfallCallback) {
+          questionHelper.getAzureSentimentAnalytics(userAns, function(
+            err,
+            sentimentResult
+          ) {
+            let obj = JSON.parse(sentimentResult);
+            totalScore.sentimentAnalyticsScore = (
+              obj.documents[0].score * 5
+            ).toFixed(2);
+            waterfallCallback(err, totalScore, trackDetails);
+          });
+        },
+
+        function(totalScore, trackDetails, waterfallCallback) {
+          trackDetails.questions[trackDetails.count].score =
+            parseFloat(totalScore.textAnalyticsScore) +
+            parseFloat(totalScore.sentimentAnalyticsScore);
+          trackDetails.score =
+            trackDetails.score +
+            parseFloat(totalScore.textAnalyticsScore) +
+            parseFloat(totalScore.sentimentAnalyticsScore);
+          trackDetails.questions[trackDetails.count].answer = userAns;
+          trackDetails.count = trackDetails.count + 1;
+
+          if (trackDetails.count >= trackDetails.questions.length) {
+            trackDetails.interview_status =
+              CONSTANTS.ENUMS.USER.INTERVIEW_STATUS.GIVEN;
+          }
+
+          trackDetails.save(function(err, savedTrack) {
+            if (err) {
+              waterfallCallback({
+                type: CONSTANTS.ERROR_TYPES.DB_ERROR,
+                msg: 'Unable to proceed',
+                errorDetail: String(err),
+              });
+            } else {
+              waterfallCallback(null, savedTrack);
+            }
+          });
+        },
+      ],
+      function(err, data) {
+        callback(err, data);
+      }
+    );
+  } else {
+    async.waterfall(
+      [
+        function(waterfallCallback) {
+          getTrackDetails(userId, trackId, function(err, trackDetails) {
+            waterfallCallback(err, trackDetails);
+          });
+        },
+
+        function(trackDetails, waterfallCallback) {
+          trackDetails.questions[trackDetails.count].score = 0;
+          trackDetails.score = trackDetails.score + 0;
+          trackDetails.questions[trackDetails.count].answer = 'Not answered';
+          trackDetails.count = trackDetails.count + 1;
+
+          if (trackDetails.count >= trackDetails.questions.length) {
+            trackDetails.interview_status =
+              CONSTANTS.ENUMS.USER.INTERVIEW_STATUS.GIVEN;
+          }
+
+          trackDetails.save(function(err, savedTrack) {
+            if (err) {
+              waterfallCallback({
+                type: CONSTANTS.ERROR_TYPES.DB_ERROR,
+                msg: 'Unable to proceed',
+                errorDetail: String(err),
+              });
+            } else {
+              waterfallCallback(null, savedTrack);
+            }
+          });
+        },
+      ],
+      function(err, data) {
+        callback(err, data);
+      }
+    );
+  }
+}
+
 module.exports = {
   startTest: startTest,
+  giveTest: giveTest,
 };


### PR DESCRIPTION
### Changes in this PR:
- Completed `interview` process with APIs
- Added functions in lib folder to calculate `sentiment` and `text` analytics score.

### Reference GitHub issues:
#110 


**API**
` [GET] /interviewee/interview/give`

**Response**
```
will give update count and new question for next API call
```
