### PR TITLE
changes for error reporting when null or empty objects are sent

### DIFF
--- a/app/controllers/interviewee/profile/additional.js
+++ b/app/controllers/interviewee/profile/additional.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const additionalLib = require('../../../../lib/interviewee/profile/additional');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,17 +11,53 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function addAdditionalDetails(req, res, next) {
-  additionalLib.addAdditionalOfInterviewee(
-    req.user._id,
-    req.body.additional,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('additional') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert description details for additional data inside object of additional property',
+      errorDetail: 'There exists no additional property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional.hasOwnProperty('description') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert description details for additional data inside object of additional property',
+      errorDetail:
+        'There exists no description propert inside additional object of requested body',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional.description == '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'The syntax to be used for request is correct. But you need to enter some string to be used in description field',
+      errorDetail:
+        'The description field is empty (Enter some of your additional achievements and hobbies)',
+    };
+    res.status(500).json(err);
+  } else if (typeof req.body.additional.description != 'string') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'The syntax to be used for request is correct. But you need to enter some string to be used in description field',
+      errorDetail: ' The data entered inside description field is NUMBER',
+    };
+    res.status(500).json(err);
+  } else {
+    additionalLib.addAdditionalOfInterviewee(
+      req.user._id,
+      req.body.additional,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
@@ -30,17 +67,69 @@ function addAdditionalDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateAdditionalDetails(req, res, next) {
-  additionalLib.updateAdditionalOfInterviewee(
-    req.user._id,
-    req.body.additional,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('additional') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert Description details for additional data inside object of additional property',
+      errorDetail: 'There exists no additional property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside additional to update any stored data',
+      errorDetail:
+        'There exists no _id property inside additional object of requested body',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside additional to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional.hasOwnProperty('description') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert Description details for additional data inside object of additional property',
+      errorDetail:
+        'There exists no description property inside additional object of requested body',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional.description == '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'The syntax to be used for request is correct. But you need to enter some string to be used in description field',
+      errorDetail:
+        'The description field is empty (Enter some of your additional achievements and hobbies)',
+    };
+    res.status(500).json(err);
+  } else if (typeof req.body.additional.description != 'string') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'The syntax to be used for request is correct. But you need to enter some string to be used in description field',
+      errorDetail: ' The data entered inside description field is NUMBER',
+    };
+    res.status(500).json(err);
+  } else {
+    additionalLib.updateAdditionalOfInterviewee(
+      req.user._id,
+      req.body.additional,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
@@ -50,17 +139,42 @@ function updateAdditionalDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function deleteAdditionalDetails(req, res, next) {
-  additionalLib.deleteAdditionalOfInterviewee(
-    req.user._id,
-    req.body.additional._id,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('additional') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id detail inside object of additional property',
+      errorDetail: 'There exists no additional property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id propert inside additional to delete any stored data',
+      errorDetail:
+        'There exists no _id propert inside additional object of requested body',
+    };
+    res.status(500).json(err);
+  } else if (req.body.additional._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id propert inside additional to delete any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    additionalLib.deleteAdditionalOfInterviewee(
+      req.user._id,
+      req.body.additional._id,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 router.post('/', addAdditionalDetails);

--- a/app/controllers/interviewee/profile/certification.js
+++ b/app/controllers/interviewee/profile/certification.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const certificationLib = require('../../../../lib/interviewee/profile/certification');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,17 +11,61 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function addCertificationDetails(req, res, next) {
-  certificationLib.addCertificationOfInterviewee(
-    req.user._id,
-    req.body.certification,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('certification') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert certifications details for certifications data inside object of certification property',
+      errorDetail: 'There exists no certification property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.certification.hasOwnProperty('name') == false ||
+    req.body.certification.hasOwnProperty('authority') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and authority field(required) inside requested Objects certification property',
+      errorDetail:
+        'There exists no property either name or authority or both inside certification object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.certification.name === '' ||
+    req.body.certification.authority === ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and authority field(required) inside requested Objects certification property',
+      errorDetail: 'name or authority or both fields are empty',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.certification.name != 'string' ||
+    typeof req.body.certification.authority != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    certificationLib.addCertificationOfInterviewee(
+      req.user._id,
+      req.body.certification,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
@@ -30,17 +75,78 @@ function addCertificationDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateCertificationDetails(req, res, next) {
-  certificationLib.updateCertificationOfInterviewee(
-    req.user._id,
-    req.body.certification,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('certification') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert certifications details for certifications data inside object of certification property',
+      errorDetail: 'There exists no certification property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.certification.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects certification property to update details of a certification',
+      errorDetail:
+        'There exists no _id property inside certification object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.certification._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside certification to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.certification.hasOwnProperty('name') == false ||
+    req.body.certification.hasOwnProperty('authority') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and authority field(required) inside requested Objects certification property',
+      errorDetail:
+        'There exists no property either name or authority or both inside certification object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.certification.name === '' ||
+    req.body.certification.authority === ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and authority field(required) inside requested Objects certification property',
+      errorDetail: 'name or authority or both fields are empty',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.certification.name != 'string' ||
+    typeof req.body.certification.authority != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    certificationLib.updateCertificationOfInterviewee(
+      req.user._id,
+      req.body.certification,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
@@ -50,17 +156,44 @@ function updateCertificationDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function deleteCertificationDetails(req, res, next) {
-  certificationLib.deleteCertificationOfInterviewee(
-    req.user._id,
-    req.body.certification._id,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('certification') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert certifications details for certifications data inside object of certification property',
+      errorDetail: 'There exists no certification property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.certification.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects certification property to update details of a certification',
+      errorDetail:
+        'There exists no _id property inside certification object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.certification._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside certification to delete any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    certificationLib.deleteCertificationOfInterviewee(
+      req.user._id,
+      req.body.certification._id,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 router.post('/', addCertificationDetails);

--- a/app/controllers/interviewee/profile/course.js
+++ b/app/controllers/interviewee/profile/course.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const courseLib = require('../../../../lib/interviewee/profile/course');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,16 +11,52 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function addCourseDetails(req, res, next) {
-  courseLib.addCourseOfInterviewee(req.user._id, req.body.course, function(
-    errInUpdation,
-    updatedInstance
-  ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+  if (req.body.hasOwnProperty('course') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert courses details for courses data inside object of course property',
+      errorDetail: 'There exists no course property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course.hasOwnProperty('name') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a name field(required) inside requested Objects course property',
+      errorDetail:
+        'There exists no name property inside course object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course.name === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a name field(required) inside requested Objects course property',
+      errorDetail:
+        'The name field is empty (Insert a specific different name from other courses name)',
+    };
+    res.status(500).json(err);
+  } else if (typeof req.body.course.name !== 'string') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    courseLib.addCourseOfInterviewee(req.user._id, req.body.course, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -29,16 +66,69 @@ function addCourseDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateCourseDetails(req, res, next) {
-  courseLib.updateCourseOfInterviewee(req.user._id, req.body.course, function(
-    errInUpdation,
-    updatedInstance
-  ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+  if (req.body.hasOwnProperty('course') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert courses details for courses data inside object of course property',
+      errorDetail: 'There exists no course property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects course property to update details of a course',
+      errorDetail:
+        'There exists no _id property inside course object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside course to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course.hasOwnProperty('name') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a name field(required) inside requested Objects course property',
+      errorDetail:
+        'There exists no name property inside course object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course.name === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a name field(required) inside requested Objects course property',
+      errorDetail:
+        'The name field is empty (Insert a specific different name from other courses name)',
+    };
+    res.status(500).json(err);
+  } else if (typeof req.body.course.name !== 'string') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    courseLib.updateCourseOfInterviewee(req.user._id, req.body.course, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -48,17 +138,43 @@ function updateCourseDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function deleteCourseDetails(req, res, next) {
-  courseLib.deleteCourseOfInterviewee(
-    req.user._id,
-    req.body.course._id,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('course') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id detail inside object of course property',
+      errorDetail: 'There exists no course property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects course property to delete details of a course',
+      errorDetail:
+        'There exists no _id property inside course object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.course._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside course to delete any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    courseLib.deleteCourseOfInterviewee(
+      req.user._id,
+      req.body.course._id,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 router.post('/', addCourseDetails);

--- a/app/controllers/interviewee/profile/degree.js
+++ b/app/controllers/interviewee/profile/degree.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const degreeLib = require('../../../../lib/interviewee/profile/degree');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,16 +11,76 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function addDegreeDetails(req, res, next) {
-  degreeLib.addDegreeOfInterviewee(req.user._id, req.body.degree, function(
-    errInUpdation,
-    updatedInstance
+  if (req.body.hasOwnProperty('degree') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert degrees details for degrees data inside object of degree property',
+      errorDetail: 'There exists no degree property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.degree.hasOwnProperty('college') == false ||
+    req.body.degree.hasOwnProperty('start_year') == false ||
+    req.body.degree.hasOwnProperty('end_year') == false ||
+    req.body.degree.hasOwnProperty('degree') == false ||
+    req.body.degree.hasOwnProperty('stream') == false ||
+    req.body.degree.performance.hasOwnProperty('scale') == false ||
+    req.body.degree.performance.hasOwnProperty('value') == false
   ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert college, start_year, end_year, degree, stream, scale and value fields(required) inside requested Objects degree property',
+      errorDetail:
+        'There exists no property either college or start_year or end_year or degree or stream or scale or value or all inside degree object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.degree.college === '' ||
+    req.body.degree.start_year === '' ||
+    req.body.degree.end_year === '' ||
+    req.body.degree.degree === '' ||
+    req.body.degree.stream === '' ||
+    req.body.degree.scale === '' ||
+    req.body.degree.value === ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert college, start_year, end_year, degree, stream, scale and value fields(required) inside requested Objects degree property',
+      errorDetail:
+        'any of college or start_year or end_year or degree or stream or scale or value fields are empty or 0',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.degree.college != 'string' ||
+    typeof req.body.degree.start_year != 'number' ||
+    typeof req.body.degree.end_year != 'number' ||
+    typeof req.body.degree.degree != 'string' ||
+    typeof req.body.degree.stream != 'string' ||
+    typeof req.body.degree.performance.scale != 'string' ||
+    typeof req.body.degree.performance.value != 'number'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    degreeLib.addDegreeOfInterviewee(req.user._id, req.body.degree, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -29,16 +90,93 @@ function addDegreeDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateDegreeDetails(req, res, next) {
-  degreeLib.updateDegreeOfInterviewee(req.user._id, req.body.degree, function(
-    errInUpdation,
-    updatedInstance
+  if (req.body.hasOwnProperty('degree') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert degrees details for degrees data inside object of degree property',
+      errorDetail: 'There exists no degree property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.degree.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects degree property to update details of a degree',
+      errorDetail:
+        'There exists no _id property inside degree object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.degree._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside degree to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.degree.hasOwnProperty('college') == false ||
+    req.body.degree.hasOwnProperty('start_year') == false ||
+    req.body.degree.hasOwnProperty('end_year') == false ||
+    req.body.degree.hasOwnProperty('degree') == false ||
+    req.body.degree.hasOwnProperty('stream') == false ||
+    req.body.degree.performance.hasOwnProperty('scale') == false ||
+    req.body.degree.performance.hasOwnProperty('value') == false
   ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert college, start_year, end_year, degree, stream, scale and value fields(required) inside requested Objects degree property',
+      errorDetail:
+        'There exists no property either college or start_year or end_year or degree or stream or scale or value or all inside degree object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.degree.college === '' ||
+    req.body.degree.start_year === '' ||
+    req.body.degree.end_year === '' ||
+    req.body.degree.degree === '' ||
+    req.body.degree.stream === '' ||
+    req.body.degree.performance.scale === '' ||
+    req.body.degree.performance.value === ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert college, start_year, end_year, degree, stream, scale and value fields(required) inside requested Objects degree property',
+      errorDetail:
+        'any of college or start_year or end_year or degree or stream or scale or value fields are empty or 0',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.degree.college != 'string' ||
+    typeof req.body.degree.start_year != 'number' ||
+    typeof req.body.degree.end_year != 'number' ||
+    typeof req.body.degree.degree != 'string' ||
+    typeof req.body.degree.stream != 'string' ||
+    typeof req.body.degree.scale != 'string' ||
+    typeof req.body.degree.value != 'number'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    degreeLib.updateDegreeOfInterviewee(req.user._id, req.body.degree, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -48,17 +186,44 @@ function updateDegreeDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function deleteDegreeDetails(req, res, next) {
-  degreeLib.deleteDegreeOfInterviewee(
-    req.user._id,
-    req.body.degree._id,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('degree') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert degrees details for degrees data inside object of degree property',
+      errorDetail: 'There exists no degree property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.degree.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects degree property to delete details of a degree',
+      errorDetail:
+        'There exists no _id property inside degree object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.degree._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside degree to delete any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    degreeLib.deleteDegreeOfInterviewee(
+      req.user._id,
+      req.body.degree._id,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 router.post('/', addDegreeDetails);

--- a/app/controllers/interviewee/profile/profession.js
+++ b/app/controllers/interviewee/profile/profession.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const professionLib = require('../../../../lib/interviewee/profile/profession');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -11,18 +12,76 @@ const router = express.Router();
  */
 function addProfessionDetails(req, res, next) {
   const profession = Object.keys(req.body)[0];
-  professionLib.addProfessionOfInterviewee(
-    req.user._id,
-    req.body[profession],
-    profession,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty(profession) == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        "Insert jobs or internships details for job's or internship's data inside object of job or internship property",
+      errorDetail: 'There exists no job or internship property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body[profession].hasOwnProperty('organization') == false ||
+    req.body[profession].hasOwnProperty('start_date') == false ||
+    req.body[profession].hasOwnProperty('currently_working') == false ||
+    req.body[profession].hasOwnProperty('profile') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert organization, profile, start_date and currently_working fields(required) inside requested Objects ' +
+        profession +
+        ' property',
+      errorDetail:
+        'There exists no property either organization or profile or start_date or currently_working or all inside ' +
+        profession +
+        ' object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body[profession].profile === '' ||
+    req.body[profession].organization === '' ||
+    req.body[profession].start_date === '' ||
+    req.body[profession].currently_working === ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert organization, profile, start_date and currently_working fields(required) inside requested Objects ' +
+        profession +
+        ' property',
+      errorDetail:
+        'any of organization or profile or start_date or currently_working or all fields are empty or 0',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body[profession].profile != 'string' ||
+    typeof req.body[profession].organization != 'string' ||
+    typeof req.body[profession].start_date != 'string' ||
+    typeof req.body[profession].currently_working != 'string'
+  ) {
+    console.log(typeof req.body[profession].currently_working);
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    professionLib.addProfessionOfInterviewee(
+      req.user._id,
+      req.body[profession],
+      profession,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
@@ -33,18 +92,101 @@ function addProfessionDetails(req, res, next) {
  */
 function updateProfessionDetails(req, res, next) {
   const profession = Object.keys(req.body)[0];
-  professionLib.updateProfessionOfInterviewee(
-    req.user._id,
-    req.body[profession],
-    profession,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty(profession) == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        "Insert jobs or internships details for job's or internship's data inside object of job or internship property",
+      errorDetail: 'There exists no job or internship property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body[profession].hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects ' +
+        profession +
+        ' property to update details of a ' +
+        profession +
+        '',
+      errorDetail:
+        'There exists no _id property inside ' +
+        profession +
+        ' object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body[profession]._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside ' +
+        profession +
+        ' to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body[profession].hasOwnProperty('organization') == false ||
+    req.body[profession].hasOwnProperty('start_date') == false ||
+    req.body[profession].hasOwnProperty('currently_working') == false ||
+    req.body[profession].hasOwnProperty('profile') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert organization, profile, start_date and currently_working fields(required) inside requested Objects ' +
+        profession +
+        ' property',
+      errorDetail:
+        'There exists no property either organization or profile or start_date or currently_working or all inside ' +
+        profession +
+        ' object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body[profession].profile === '' ||
+    req.body[profession].organization === '' ||
+    req.body[profession].start_date === '' ||
+    req.body[profession].currently_working === ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert organization, profile, start_date and currently_working fields(required) inside requested Objects ' +
+        profession +
+        ' property',
+      errorDetail:
+        'any of organization or profile or start_date or currently_working or all fields are empty or 0',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body[profession].profile != 'string' ||
+    typeof req.body[profession].organization != 'string' ||
+    typeof req.body[profession].start_date != 'string' ||
+    typeof req.body[profession].currently_working != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    professionLib.updateProfessionOfInterviewee(
+      req.user._id,
+      req.body[profession],
+      profession,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
@@ -55,18 +197,54 @@ function updateProfessionDetails(req, res, next) {
  */
 function deleteProfessionDetails(req, res, next) {
   const profession = Object.keys(req.body)[0];
-  professionLib.deleteProfessionOfInterviewee(
-    req.user._id,
-    req.body[profession]._id,
-    profession,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty(profession) == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        "Insert jobs or internships details for job's or internship's data inside object of job or internship property",
+      errorDetail: 'There exists no job or internship property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body[profession].hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects ' +
+        profession +
+        ' property to update details of a ' +
+        profession +
+        '',
+      errorDetail:
+        'There exists no _id property inside ' +
+        profession +
+        ' object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body[profession]._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside ' +
+        profession +
+        ' to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    professionLib.deleteProfessionOfInterviewee(
+      req.user._id,
+      req.body[profession]._id,
+      profession,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 router.post('/', addProfessionDetails);

--- a/app/controllers/interviewee/profile/project.js
+++ b/app/controllers/interviewee/profile/project.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const projectLib = require('../../../../lib/interviewee/profile/project');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,16 +11,61 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function addProjectDetails(req, res, next) {
-  projectLib.addProjectOfInterviewee(req.user._id, req.body.project, function(
-    errInUpdation,
-    updatedInstance
+  if (req.body.hasOwnProperty('project') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert projects details for project data inside object of project property',
+      errorDetail: 'There exists no project property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.project.hasOwnProperty('title') == false ||
+    req.body.project.hasOwnProperty('description') == false
   ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a title and description field(required) inside requested Objects project property',
+      errorDetail:
+        'There exists no title or description or both property inside project object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.project.title == '' ||
+    req.body.project.description == ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a title and description field(required) inside requested Objects project property',
+      errorDetail:
+        'The title or description or both fields are empty (Insert a specific different title from other projects title and a brief specific description of your project)',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.project.description != 'string' ||
+    typeof req.body.project.title != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    projectLib.addProjectOfInterviewee(req.user._id, req.body.project, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -29,17 +75,79 @@ function addProjectDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateProjectDetails(req, res, next) {
-  projectLib.updateProjectOfInterviewee(
-    req.user._id,
-    req.body.project,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('project') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert projects details for project data inside object of project property',
+      errorDetail: 'There exists no project property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.project.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects project property to update details of a project',
+      errorDetail:
+        'There exists no _id property inside project object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.project._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside project to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.project.hasOwnProperty('title') == false ||
+    req.body.project.hasOwnProperty('description') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a title and description field(required) inside requested Objects project property',
+      errorDetail:
+        'There exists no title or description or both property inside project object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.project.title == '' ||
+    req.body.project.description == ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a title and description field(required) inside requested Objects project property',
+      errorDetail:
+        'The title ot description or both fields are empty (Insert a specific different title from other projects title and a brief specific description of your project)',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.project.description != 'string' ||
+    typeof req.body.project.title != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    projectLib.updateProjectOfInterviewee(
+      req.user._id,
+      req.body.project,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**
@@ -49,17 +157,43 @@ function updateProjectDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function deleteProjectDetails(req, res, next) {
-  projectLib.deleteProjectOfInterviewee(
-    req.user._id,
-    req.body.project._id,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('project') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id detail inside object of project property',
+      errorDetail: 'There exists no project property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.project.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects project property to delete details of a project',
+      errorDetail:
+        'There exists no _id property inside project object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.project._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside project to delete any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    projectLib.deleteProjectOfInterviewee(
+      req.user._id,
+      req.body.project._id,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 router.post('/', addProjectDetails);

--- a/app/controllers/interviewee/profile/secondary.js
+++ b/app/controllers/interviewee/profile/secondary.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const secondaryLib = require('../../../../lib/interviewee/profile/secondary');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,17 +11,82 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateSecondaryDetails(req, res, next) {
-  secondaryLib.updateSecondaryOfInterviewee(
-    req.user._id,
-    req.body.secondary,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('secondary') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert secondarys details for secondarys data inside object of secondary property',
+      errorDetail: 'There exists no secondary property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.secondary.hasOwnProperty('school') == false ||
+    req.body.secondary.hasOwnProperty('board') == false ||
+    req.body.secondary.hasOwnProperty('year_of_comp') == false ||
+    req.body.secondary.hasOwnProperty('performance') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert school, board, year_of_comp and performance field(required) inside requested Objects secondary property',
+      errorDetail:
+        'There exists either no school or board or year_of_comp or performace property inside secondary object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.secondary.performance.hasOwnProperty('scale') == false ||
+    req.body.secondary.performance.hasOwnProperty('value') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert scale and value field(required) inside requested Objects secondary property',
+      errorDetail:
+        'There exists either no scale or value property inside secondary object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.secondary.school == '' ||
+    req.body.secondary.board == '' ||
+    req.body.secondary.year_of_comp == '' ||
+    req.body.secondary.performance.scale == '' ||
+    req.body.secondary.performance.value == ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert school, board, year_of_comp, scale and value field field(required) inside requested Objects secondary property',
+      errorDetail:
+        'Either school or board or year_of_comp or performance(scale and value) or all fields are empty or 0 (Insert a specific different school from other secondarys school)',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.secondary.school != 'string' ||
+    typeof req.body.secondary.board != 'string' ||
+    typeof req.body.secondary.year_of_comp != 'number' ||
+    typeof req.body.secondary.performance.scale != 'string' ||
+    typeof req.body.secondary.performance.value != 'number'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    secondaryLib.updateSecondaryOfInterviewee(
+      req.user._id,
+      req.body.secondary,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 router.put('/', updateSecondaryDetails);

--- a/app/controllers/interviewee/profile/seniorSecondary.js
+++ b/app/controllers/interviewee/profile/seniorSecondary.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const seniorSecondaryLib = require('../../../../lib/interviewee/profile/seniorSecondary');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,17 +11,84 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateSeniorSecondaryDetails(req, res, next) {
-  seniorSecondaryLib.updateSeniorSecondaryOfInterviewee(
-    req.user._id,
-    req.body.senior_secondary,
-    function(errInUpdation, updatedInstance) {
-      if (errInUpdation) {
-        res.status(500).json(errInUpdation);
-      } else {
-        res.status(200).json(updatedInstance);
+  if (req.body.hasOwnProperty('senior_secondary') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert senior_secondarys details for senior_secondarys data inside object of senior_secondary property',
+      errorDetail: 'There exists no senior_secondary property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.senior_secondary.hasOwnProperty('school') == false ||
+    req.body.senior_secondary.hasOwnProperty('board') == false ||
+    req.body.senior_secondary.hasOwnProperty('stream') == false ||
+    req.body.senior_secondary.hasOwnProperty('year_of_comp') == false ||
+    req.body.senior_secondary.hasOwnProperty('performance') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert school, board, stream, year_of_comp and performance field(required) inside requested Objects senior_secondary property',
+      errorDetail:
+        'There exists either no school or board or stream or year_of_comp or performace property inside senior_secondary object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.senior_secondary.performance.hasOwnProperty('scale') == false ||
+    req.body.senior_secondary.performance.hasOwnProperty('value') == false
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert scale and value field(required) inside requested Objects senior_secondary property',
+      errorDetail:
+        'There exists either no scale or value property inside senior_secondary object for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.senior_secondary.school == '' ||
+    req.body.senior_secondary.board == '' ||
+    req.body.senior_secondary.year_of_comp == '' ||
+    req.body.senior_secondary.stream == '' ||
+    req.body.senior_secondary.performance.scale == '' ||
+    req.body.senior_secondary.performance.value == ''
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert school, board, year_of_comp, scale and value field field(required) inside requested Objects senior_secondary property',
+      errorDetail:
+        'Either school or board or year_of_comp or performance(scale and value) or all fields are empty or 0 (Insert a specific different school from other senior_secondarys school)',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.senior_secondary.school != 'string' ||
+    typeof req.body.senior_secondary.board != 'string' ||
+    typeof req.body.senior_secondary.year_of_comp != 'number' ||
+    typeof req.body.senior_secondary.performance.scale != 'string' ||
+    typeof req.body.senior_secondary.performance.value != 'number'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    seniorSecondaryLib.updateSeniorSecondaryOfInterviewee(
+      req.user._id,
+      req.body.senior_secondary,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
       }
-    }
-  );
+    );
+  }
 }
 
 /**

--- a/app/controllers/interviewee/profile/skill.js
+++ b/app/controllers/interviewee/profile/skill.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const skillLib = require('../../../../lib/interviewee/profile/skill');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,16 +11,58 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function addSkillDetails(req, res, next) {
-  skillLib.addSkillOfInterviewee(req.user._id, req.body.skill, function(
-    errInUpdation,
-    updatedInstance
+  if (req.body.hasOwnProperty('skill') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert skills details for skills data inside object of skill property',
+      errorDetail: 'There exists no skill property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.skill.hasOwnProperty('name') == false ||
+    req.body.skill.hasOwnProperty('rate') == false
   ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a rate and name field(required) inside requested Objects skill property',
+      errorDetail:
+        'There exists no name or rate or both property inside skill object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.skill.name === '' || req.body.skill.rate === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a rate and name field(required) inside requested Objects skill property',
+      errorDetail:
+        'The rate or name or both fields are empty (Insert a specific value for rate from enum having value - Beginner, Intermediate and Advanced)',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.skill.rate != 'string' ||
+    typeof req.body.skill.name != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    skillLib.addSkillOfInterviewee(req.user._id, req.body.skill, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -29,16 +72,74 @@ function addSkillDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateSkillDetails(req, res, next) {
-  skillLib.updateSkillOfInterviewee(req.user._id, req.body.skill, function(
-    errInUpdation,
-    updatedInstance
+  if (req.body.hasOwnProperty('skill') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert skills details for skills data inside object of skill property',
+      errorDetail: 'There exists no skill property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.skill.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects skill property to update details of a skill',
+      errorDetail: 'There exists no _id property inside skill object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.skill._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside skill to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.skill.hasOwnProperty('name') == false ||
+    req.body.skill.hasOwnProperty('rate') == false
   ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a rate and name field(required) inside requested Objects skill property',
+      errorDetail:
+        'There exists no name or rate or both property inside skill object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.skill.name === '' || req.body.skill.rate === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert a rate and name field(required) inside requested Objects skill property',
+      errorDetail:
+        'The rate or name  or both fields are empty (Insert a specific value from enum having value - Beginner, Intermediate and Advanced)',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.skill.rate != 'string' ||
+    typeof req.body.skill.name != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    skillLib.updateSkillOfInterviewee(req.user._id, req.body.skill, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -48,16 +149,42 @@ function updateSkillDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function deleteSkillDetails(req, res, next) {
-  skillLib.deleteSkillOfInterviewee(req.user._id, req.body.skill._id, function(
-    errInUpdation,
-    updatedInstance
-  ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+  if (req.body.hasOwnProperty('skill') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id detail inside object of skill property',
+      errorDetail: 'There exists no skill property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.skill.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects skill property to delete details of a skill',
+      errorDetail: 'There exists no _id property inside skill object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.skill._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside skill to delete any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    skillLib.deleteSkillOfInterviewee(
+      req.user._id,
+      req.body.skill._id,
+      function(errInUpdation, updatedInstance) {
+        if (errInUpdation) {
+          res.status(500).json(errInUpdation);
+        } else {
+          res.status(200).json(updatedInstance);
+        }
+      }
+    );
+  }
 }
 
 router.post('/', addSkillDetails);

--- a/app/controllers/interviewee/profile/test.js
+++ b/app/controllers/interviewee/profile/test.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const testLib = require('../../../../lib/interviewee/profile/test');
+const CONSTANTS = require('../../../../config/constants');
 
 const router = express.Router();
 
@@ -10,16 +11,56 @@ const router = express.Router();
  * @param {Function} next Function to pass control to the next middleware
  */
 function addTestDetails(req, res, next) {
-  testLib.addTestOfInterviewee(req.user._id, req.body.test, function(
-    errInUpdation,
-    updatedInstance
+  if (req.body.hasOwnProperty('test') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert tests details for tests data inside object of test property',
+      errorDetail: 'There exists no test property for usage',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.test.hasOwnProperty('name') == false ||
+    req.body.test.hasOwnProperty('score') == false
   ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and score field(required) inside requested Objects test property',
+      errorDetail:
+        'There exists no property either name or score or both inside test object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.test.name === '' || req.body.test.score === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and score field(required) inside requested Objects test property',
+      errorDetail: 'name or score or both fields are empty',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.test.name != 'string' ||
+    typeof req.body.test.score != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    testLib.addTestOfInterviewee(req.user._id, req.body.test, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -29,16 +70,72 @@ function addTestDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function updateTestDetails(req, res, next) {
-  testLib.updateTestOfInterviewee(req.user._id, req.body.test, function(
-    errInUpdation,
-    updatedInstance
+  if (req.body.hasOwnProperty('test') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert tests details for tests data inside object of test property',
+      errorDetail: 'There exists no test property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.test.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects test property to update details of a test',
+      errorDetail: 'There exists no _id property inside test object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.test._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside test to update any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else if (
+    req.body.test.hasOwnProperty('name') == false ||
+    req.body.test.hasOwnProperty('score') == false
   ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and score field(required) inside requested Objects test property',
+      errorDetail:
+        'There exists no property either name or score or both inside test object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.test.name === '' || req.body.test.score === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert name and score field(required) inside requested Objects test property',
+      errorDetail: 'name or score or both fields are empty',
+    };
+    res.status(500).json(err);
+  } else if (
+    typeof req.body.test.name != 'string' ||
+    typeof req.body.test.score != 'string'
+  ) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert correct values for property to be stored',
+      errorDetail:
+        'There exists some incorrect value for some property inside object requested',
+    };
+    res.status(500).json(err);
+  } else {
+    testLib.updateTestOfInterviewee(req.user._id, req.body.test, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 /**
@@ -48,16 +145,41 @@ function updateTestDetails(req, res, next) {
  * @param {Function} next Function to pass control to the next middleware
  */
 function deleteTestDetails(req, res, next) {
-  testLib.deleteTestOfInterviewee(req.user._id, req.body.test._id, function(
-    errInUpdation,
-    updatedInstance
-  ) {
-    if (errInUpdation) {
-      res.status(500).json(errInUpdation);
-    } else {
-      res.status(200).json(updatedInstance);
-    }
-  });
+  if (req.body.hasOwnProperty('test') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert tests details for tests data inside object of test property',
+      errorDetail: 'There exists no test property for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.test.hasOwnProperty('_id') == false) {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg:
+        'Insert _id property inside requested Objects test property to delete details of a test',
+      errorDetail: 'There exists no _id property inside test object for usage',
+    };
+    res.status(500).json(err);
+  } else if (req.body.test._id === '') {
+    let err = {
+      type: CONSTANTS.ERROR_TYPES.INCORRECT_PAYLOAD,
+      msg: 'Insert _id property inside test to delete any stored data',
+      errorDetail:
+        '_id property is empty and doesnot contain any ObjectId string with a type as STRING',
+    };
+    res.status(500).json(err);
+  } else {
+    testLib.deleteTestOfInterviewee(req.user._id, req.body.test._id, function(
+      errInUpdation,
+      updatedInstance
+    ) {
+      if (errInUpdation) {
+        res.status(500).json(errInUpdation);
+      } else {
+        res.status(200).json(updatedInstance);
+      }
+    });
+  }
 }
 
 router.post('/', addTestDetails);

--- a/app/helpers/user.js
+++ b/app/helpers/user.js
@@ -116,6 +116,7 @@ function getIntervieweeDetails(userId, callback) {
  * @param {Function} callback function two param errInFetch and experience
  */
 function getTotalExperience(userId, callback) {
+  let ed = new Date();
   Interviewee.aggregate(
     [
       {
@@ -133,7 +134,12 @@ function getTotalExperience(userId, callback) {
           duration: {
             $divide: [
               {
-                $subtract: ['$jobs.end_date', '$jobs.start_date'],
+                $subtract: [
+                  {
+                    $cond: ['$jobs.currently_working', ed, '$jobs.end_date'],
+                  },
+                  '$jobs.start_date',
+                ],
               },
               1000 * 60 * 60 * 24 * 365,
             ],

--- a/app/models/Interviewee/Certification.js
+++ b/app/models/Interviewee/Certification.js
@@ -12,11 +12,9 @@ const certificationSchema = new Schema({
   },
   lic_number: {
     type: String,
-    required: true,
   },
   url: {
     type: String,
-    required: true,
   },
 });
 

--- a/lib/interviewee/profile/skill.js
+++ b/lib/interviewee/profile/skill.js
@@ -24,18 +24,32 @@ function addSkillOfInterviewee(userId, skillData, callback) {
       },
 
       function(fetchedInterviewee, waterfallCallback) {
-        fetchedInterviewee.skills.push(skillData);
-        fetchedInterviewee.save(function(errInSave, savedInterviewee) {
-          if (errInSave) {
-            waterfallCallback({
-              type: CONSTANTS.ERROR_TYPES.DB_ERROR,
-              msg: 'Unable to add new Skill Details',
-              errorDetail: JSON.stringify(errInSave),
-            });
-          } else {
-            waterfallCallback(null, savedInterviewee);
-          }
+        const skills = fetchedInterviewee.skills.map(
+          eachskills => eachskills.name
+        );
+        const skills_to_up = skills.map(function(x) {
+          return x.toUpperCase();
         });
+        if (skills_to_up.includes(skillData.name.toUpperCase())) {
+          waterfallCallback({
+            type: CONSTANTS.ERROR_TYPES.INVALID_RECORD,
+            msg: 'Skill already exists in the skills array of user',
+            errorDetail: 'Write some other skill to be stored',
+          });
+        } else {
+          fetchedInterviewee.skills.push(skillData);
+          fetchedInterviewee.save(function(errInSave, savedInterviewee) {
+            if (errInSave) {
+              waterfallCallback({
+                type: CONSTANTS.ERROR_TYPES.DB_ERROR,
+                msg: 'Unable to add new Skill Details',
+                errorDetail: JSON.stringify(errInSave),
+              });
+            } else {
+              waterfallCallback(null, savedInterviewee);
+            }
+          });
+        }
       },
     ],
     function(err, data) {
@@ -51,31 +65,63 @@ function addSkillOfInterviewee(userId, skillData, callback) {
  * @param {Object} callback has two parameters first errorInSave and Saved Interviewee Details
  */
 function updateSkillOfInterviewee(userId, skillData, callback) {
-  Interviewee.findOneAndUpdate(
-    {
-      userId: userId,
-      skills: {
-        $elemMatch: {
-          _id: mongoose.Types.ObjectId(skillData._id),
-        },
-      },
-    },
-    {
-      $set: {
-        'skills.$.rate': skillData.rate,
-        'skills.$.name': skillData.name,
-      },
-    },
-    function(errInSave, returnedInstance) {
-      if (errInSave) {
-        callback({
-          type: CONSTANTS.ERROR_TYPES.DB_ERROR,
-          msg: 'Unable to update existing Skill Details',
-          errorDetail: JSON.stringify(errInSave),
+  async.waterfall(
+    [
+      function(waterfallCallback) {
+        userHelper.getIntervieweeDetails(userId, function(
+          err,
+          fetchedInterviewee
+        ) {
+          waterfallCallback(err, fetchedInterviewee);
         });
-      } else {
-        callback(null, returnedInstance);
-      }
+      },
+
+      function(fetchedInterviewee, waterfallCallback) {
+        const skills = fetchedInterviewee.skills.map(
+          eachskills => eachskills.name
+        );
+        const skills_to_up = skills.map(function(x) {
+          return x.toUpperCase();
+        });
+        if (skills_to_up.includes(skillData.name.toUpperCase())) {
+          waterfallCallback({
+            type: CONSTANTS.ERROR_TYPES.INVALID_RECORD,
+            msg: 'Skill already exists in the skills array of user',
+            errorDetail: 'Write some other skill to be stored',
+          });
+        } else {
+          Interviewee.findOneAndUpdate(
+            {
+              userId: userId,
+              skills: {
+                $elemMatch: {
+                  _id: mongoose.Types.ObjectId(skillData._id),
+                },
+              },
+            },
+            {
+              $set: {
+                'skills.$.rate': skillData.rate,
+                'skills.$.name': skillData.name,
+              },
+            },
+            function(errInSave, returnedInstance) {
+              if (errInSave) {
+                waterfallCallback({
+                  type: CONSTANTS.ERROR_TYPES.DB_ERROR,
+                  msg: 'Unable to update existing Skill Details',
+                  errorDetail: JSON.stringify(errInSave),
+                });
+              } else {
+                waterfallCallback(null, returnedInstance);
+              }
+            }
+          );
+        }
+      },
+    ],
+    function(err, data) {
+      callback(err, data);
     }
   );
 }


### PR DESCRIPTION
### Changes in this PR:
errors will now be reported when object sent as request body is empty, null or required fields are not present

- `additional`: **description** are required when using `addAdditionalDetails` and also **_id** is required when using `updateAdditionalDetails` and only **_id** is required under `deleteAdditionalDetails`
- `certification`: **name** and **authority** are required when using `addCertificationDetails` and also **_id** is required when using `updateCertificationDetails` and only **_id** i required under `deleteCertificationDetails`
- `course`: **name** is required when using `addCourseDetails` and also **_id** is required when using `updateCourseDetails` and only **_id** is required under `deleteCourseDetails`
- `degree`: **college**, **start_year**, **end_year**, **degree**, **stream**, **performance**(scale and value) are required when using `addDegreeDetails` and also **_id** when using `updateDegreeDetails` and only **_id** is required under `deleteDegreeDetails`
- `profession`: **profile**, **organization**, **start_date**, **currently_working** are required when using `addProfessionDetails` and also **_id** when using `updateProfessionDetails` and only **_id** is required under `deleteProfessionDetails`
- `project`: **title** and **description** are required when using `addProjectDetails` and also **_id** when using `updateProjectDetails` and only **_id** is required under `deletePrjectDetails`
- `secondary`: school, board, year_of_comp, performance(scale and value) are required when using `updateSecondaryDetails`
- `seniorSecondary`: school, board, stream, year_of_comp, performance(scale and value) are required when using `updateSeniorSecondaryDetails`
- `skill`: **name** and **rate** re required when using `addSkillDetails` and also **_id** when using `updateSkillDetails` and only **_id** is required under `deleteSkillDetails`
- `test`: **name** and **score** are required when using `addTestDetails` and also **_id** when using `updateTestDetails` and only **_id** is required under `deleteTestDetails`


and **Interviewee** needs to enter different skill names for storing no redundancy will be accepted under both addition of new skill and updation of previous one

and when someone during filling job details,  checks **currently_working** checkbox then during calculation of his/her experience present date will be used over that job experience calculation 
under `getTotalExperience` function

### Sample API Consumption
**API**
` [POST] /interviewee/profile/additional`
` [PUT] /interviewee/profile/additional`
` [DELETE] /interviewee/profile/additional`

` [POST] /interviewee/profile/certification`
` [PUT] /interviewee/profile/certification`
` [DELETE] /interviewee/profile/certification`

` [POST] /interviewee/profile/course`
` [PUT] /interviewee/profile/course`
` [DELETE] /interviewee/profile/course`

` [POST] /interviewee/profile/degree`
` [PUT] /interviewee/profile/degree`
` [DELETE] /interviewee/profile/degree`

` [POST] /interviewee/profile/profession`
` [PUT] /interviewee/profile/profession`
` [DELETE] /interviewee/profile/profession`

` [POST] /interviewee/profile/project`
` [PUT] /interviewee/profile/project`
` [DELETE] /interviewee/profile/project`

` [PUT] /interviewee/profile/secondary`

` [PUT] /interviewee/profile/seniorSecondary`
` [DELETE] /interviewee/profile/seniorSecondary`

` [POST] /interviewee/profile/skill`
` [PUT] /interviewee/profile/skill`
` [DELETE] /interviewee/profile/skill`

` [POST] /interviewee/profile/test`
` [PUT] /interviewee/profile/test`
` [DELETE] /interviewee/profile/test`

